### PR TITLE
Removed the copyright transfer provision from the License.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -60,7 +60,7 @@ TODO
 
 h2(#license). %4.% License
 
-Brave Core Service API Bindings has been released under the MIT Open Source license.  All contributors agree to transfer ownership of their code to Alice Bevan-McGregor for release under this license.  (This is to mitigate issues in the future.)
+Brave Core Service API Bindings has been released under the MIT Open Source license.
 
 
 h3(#license-mit). %4.1.% The MIT License


### PR DESCRIPTION
Signed-off-by: Tyler O'Meara Tyler@TylerOMeara.com
