### PR TITLE
Fix package name in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys, os
 from setuptools import setup, find_packages
 
 setup(
-        name = "Brave Core Service API Bindings",
+        name = "brave.api",
         version = "0.1",
         description = "Python API bindings for both utilizing and hosting the secure RPC mechanism.",
         author = "Alice Bevan-McGregor",


### PR DESCRIPTION
This will make setup run smoothly for things which depend on this (e.g. the core build: https://travis-ci.org/bravecollective/core/builds)
