### PR TITLE
Check the second before the listed date in the headers when verifying signatures.

### DIFF
--- a/brave/api/controller.py
+++ b/brave/api/controller.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 from datetime import datetime
 from binascii import hexlify, unhexlify
 from hashlib import sha256
-from ecdsa.keys import SigningKey, VerifyingKey
+from ecdsa.keys import SigningKey, VerifyingKey, BadSignatureError
 from ecdsa.curves import NIST256p
 
 from webob import Response
@@ -38,11 +38,20 @@ class SignedController(Controller):
         key = VerifyingKey.from_string(unhexlify(hex_key), curve=NIST256p, hashfunc=sha256)
         
         log.debug("Canonical request:\n\n\"{r.headers[Date]}\n{r.url}\n{r.body}\"".format(r=request))
-        
-        if not key.verify(
+        date = datetime.strptime(response.headers['Date'], '%a, %d %b %Y %H:%M:%S GMT')
+        date = date - timedelta(seconds=1)
+
+        try:
+            key.verify(
                 unhexlify(request.headers['X-Signature']),
-                "{r.headers[Date]}\n{r.url}\n{r.body}".format(r=request)):
-            raise HTTPBadRequest("Invalid request signature.")
+                "{r.headers[Date]}\n{r.url}\n{r.body}".format(r=request))
+        except BadSignatureError:
+            try:
+                key.verify(
+                    unhexlify(request.headers['X-Signature']),
+                    "{date}\n{r.url}\n{r.body}".format(r=request, date=date.strftime('%a, %d %b %Y %H:%M:%S GMT')))
+            except BadSignatureError:
+                raise HTTPBadRequest("Invalid request signature.")
         
         return args, kw
     

--- a/brave/api/controller.py
+++ b/brave/api/controller.py
@@ -13,6 +13,8 @@ from web.core.http import HTTPBadRequest
 from web.core import request, Controller
 from web.core.templating import render
 
+from datetime import datetime, timedelta
+
 
 log = __import__('logging').getLogger(__name__)
 
@@ -38,7 +40,7 @@ class SignedController(Controller):
         key = VerifyingKey.from_string(unhexlify(hex_key), curve=NIST256p, hashfunc=sha256)
         
         log.debug("Canonical request:\n\n\"{r.headers[Date]}\n{r.url}\n{r.body}\"".format(r=request))
-        date = datetime.strptime(response.headers['Date'], '%a, %d %b %Y %H:%M:%S GMT')
+        date = datetime.strptime(request.headers['Date'], '%a, %d %b %Y %H:%M:%S GMT')
         date = date - timedelta(seconds=1)
 
         try:


### PR DESCRIPTION
Due to the signature being calculated before the final date stamp is
applied to the header (thanks requests), we have to check for the
second before the listed date as well before rejecting the signature.
This fixes the occasional BadSignatureError issue that's been occurring.

Signed-off-by: Tyler O'Meara Tyler@TylerOMeara.com
