### PR TITLE
Add time check to validation.

### DIFF
--- a/brave/api/client.py
+++ b/brave/api/client.py
@@ -11,6 +11,8 @@ from hashlib import sha256
 from webob import Response
 from marrow.util.bunch import Bunch
 from requests.auth import AuthBase
+from ecdsa.keys import BadSignatureError
+from datetime import datetime, timedelta
 
 
 log = __import__('logging').getLogger(__name__)
@@ -69,6 +71,15 @@ class SignedAuth(AuthBase):
         log.info("Validating %s request signature: %s", self.identity, response.headers['X-Signature'])
         canon = "{ident}\n{r.headers[Date]}\n{r.url}\n{r.text}".format(ident=self.identity, r=response)
         log.debug("Canonical data:\n%r", canon)
+
+        date = datetime.strptime(response.headers['Date'], '%a, %d %b %Y %H:%M:%S GMT')
+        if datetime.utcnow() - date > timedelta(seconds=15):
+            log.warning("Received response that is over 15 seconds old, rejecting.")
+            raise BadSignatureError
+
+        if datetime.utcnow() - date < timedelta(seconds=0):
+            log.warning("Received a request from the future; please check this systems time for validity.")
+            raise BadSignatureError
         
         # Raises an exception on failure.
         self.public.verify(


### PR DESCRIPTION
The client and controller both check that the time specified in the
date header is no more than 15 seconds old, and no less than 0 seconds
ahead of the current time. This should prevent replay attacks (as the
date in the header is part of the signature).

Signed-off-by: Tyler O'Meara Tyler@TylerOMeara.com
